### PR TITLE
Recycle magic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BinderPlots"
 uuid = "5e41213d-62ae-4ae0-a5b0-867e743d03c0"
 authors = ["jverzani <jverzani@gmail.com> and contributors"]
-version = "1.0.8"
+version = "1.0.9"
 
 [deps]
 PlotUtils = "995b91a9-d308-5afd-9ec6-746e21dbc043"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # BinderPlots
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://jverzani.github.io/BinderPlots.jl/stable/)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://jverzani.github.io/BinderPlots.jl/dev/)
 [![Build Status](https://github.com/jverzani/BinderPlots.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/jverzani/BinderPlots.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/jverzani/BinderPlots.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/jverzani/BinderPlots.jl)

--- a/docs/src/basic-graphics.md
+++ b/docs/src/basic-graphics.md
@@ -225,7 +225,7 @@ There are a few simple shapes, including lines:
 
 * `hline!(y; xmin=0,xmax=1)` draws a horizontal line at elevation `y` across the computed axis, or adjusted via `xmin` and `xmax`.  The `extrema` function computes the axis sizes. If `y` is a container, multiple lines are drawn.
 * `vline(x)`  draws a vertical line at  `x` across the computed axis, or adjusted via `ymin` and `ymax`. The `extrema` function computes the axis sizes. If `x` is a container, multiple lines are drawn.
-* `ablines!(intercept, slope)` for drawing lines `a + bx` in the current frame.
+* `abline!(intercept, slope)` for drawing lines `a + bx` in the current frame.
 
 The following create regions which can be filled.  Shapes have an interior and exterior boundary. The exterior line has attributes that can be adjusted with `linecolor`, `linewidth`, and `linestyle`.
 
@@ -280,7 +280,7 @@ As seen in this overblown example, there are other methods besides `plot` for ot
 
 * `quiver!` is used to add arrows to a plot. These can optionally have their tails labeled, so this method can be repurposed to add annotations.  The `quiver` command allows for text rotation. Also `arrow` and `arrows` for different interfaces for drawing arrows. The `annotate!` function is used to add annotations at a given point. There are keyword arguments to adjust the text size, color, font-family, etc.
 
-* `rect!` is used to make a rectangle. There are also `hspan!` and `vspan!`. For lines, there are `hline!` and `vline!` to draw horizontal or vertical lines across the extent of the plotting region. There is also `ablines!` to draw lines specified in intercept-slope form across the extent of the plotting region. Other regions can be draws. For example, `circle!` to draw a circle, and, more generally, `poly` can be used to draw a polygonal region.
+* `rect!` is used to make a rectangle. There are also `hspan!` and `vspan!`. For lines, there are `hline!` and `vline!` to draw horizontal or vertical lines across the extent of the plotting region. There is also `abline!` to draw lines specified in intercept-slope form across the extent of the plotting region. Other regions can be draws. For example, `circle!` to draw a circle, and, more generally, `poly` can be used to draw a polygonal region.
 
 
 

--- a/src/2d-plots.jl
+++ b/src/2d-plots.jl
@@ -8,9 +8,26 @@ SeriesType(::Val{:heatmap}) = (:heatmap, :heatmap)
 ContourTypes = Union{Val{:contour}, Val{:heatmap},
                      Val{:surface}, Val{:wireframe}}
 
-# PLots for making polygons
-Shape(x, y) = zip(x, y)
-Shape(x) = x
+# create a blank canvas with a give size, etc.
+function blank_canvas(;
+                      xlim=nothing, xlims=xlim,
+                      ylim=nothing, ylims=ylim,
+                      aspect_ratio=:equal,
+                      border=:none, legend=false,
+                      kwargs...)
+    p = plot(; xlims, ylims,
+             aspect_ratio,
+             border, legend,
+             kwargs...)
+    for a ∈ (p.layout.xaxis, p.layout.yaxis)
+        _axisstyle!(a,
+                    showticklabels =false,
+                    showgrid = false,
+                    zeroline = false)
+    end
+    p
+
+end
 
 function plot!(t::T, m::M, p::Plot, x, y, z;
                kwargs...) where {T <: ContourTypes, M<:ContourTypes}

--- a/src/BinderPlots.jl
+++ b/src/BinderPlots.jl
@@ -105,6 +105,7 @@ export Plot, Config # but not Preset, preset, plot
 
 export plot, plot!, scatter, scatter!
 export Shape
+#export Poly, rotate, translate, shear  # <<- not such a good idea?
 export contour, contour!, contourf, contourf!, heatmap, heatmap!
 export surface, surface!, wireframe, wireframe!
 export plot_implicit, plot_implicit!
@@ -120,7 +121,7 @@ export parallelogram, parallelogram!, circ3d, circ3d!, skirt, skirt!
 export current
 
 
-export arrows, arrows!, poly, poly!, band, band!, hspan!, vspan!, ablines!, image!
+export arrows, arrows!, poly, poly!, band, band!, hspan!, vspan!, abline!, image!
 #export unzip
 export rgb, colormap
 

--- a/src/annotate.jl
+++ b/src/annotate.jl
@@ -17,7 +17,7 @@ The `x`, `y`, `txt` values can be specified as 3 iterables or tuple of tuples.
 function annotate!(p::Plot, x, y, txt;
                    kwargs...)
 
-    # txt may be string or 'text' objects
+    # txt maybe string or 'text' objects
     # convert string to text object then ...
     tfs = [text(tᵢ) for tᵢ ∈ txt]
     _txt = [t.str for t in tfs]
@@ -34,11 +34,20 @@ function annotate!(p::Plot, x, y, txt;
     p
 end
 
-annotate!(p::Plot, anns::Tuple; kwargs...) = annotate!(p, unzip(anns)...; kwargs...)
-annotate!(p::Plot, anns::Vector; kwargs...) = annotate!(p, unzip(anns)...; kwargs...)
 annotate!(x, y, txt; kwargs...) = annotate!(current_plot[], x, y, txt; kwargs...)
 annotate!(anns::Tuple; kwargs...) = annotate!(current_plot[], anns; kwargs...)
 annotate!(anns::Vector; kwargs...) = annotate!(current_plot[], anns; kwargs...)
+
+annotate!(p::Plot, anns::Tuple; kwargs...) = annotate!(p, collect(anns)...; kwargs...)
+
+# use magic to create `text` objects
+function annotate!(p::Plot, anns::Vector; kwargs...)
+    x = [a[1] for a in anns]
+    y = [a[2] for a in anns]
+    txt = [text(a[3:end]...) for a in anns]
+    annotate!(p, x, y, txt; kwargs...)
+end
+
 
 ## ----
 

--- a/src/annotate.jl
+++ b/src/annotate.jl
@@ -38,7 +38,7 @@ annotate!(x, y, txt; kwargs...) = annotate!(current_plot[], x, y, txt; kwargs...
 annotate!(anns::Tuple; kwargs...) = annotate!(current_plot[], anns; kwargs...)
 annotate!(anns::Vector; kwargs...) = annotate!(current_plot[], anns; kwargs...)
 
-annotate!(p::Plot, anns::Tuple; kwargs...) = annotate!(p, collect(anns)...; kwargs...)
+annotate!(p::Plot, anns::Tuple; kwargs...) = annotate!(p, collect(anns); kwargs...)
 
 # use magic to create `text` objects
 function annotate!(p::Plot, anns::Vector; kwargs...)

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -25,7 +25,8 @@ function plot!(::Val{:scatter}, p::Plot, x=nothing, y=nothing, z=nothing;
     _,mode = SeriesType(seriestype)
     KWs = Recycler(kwargs)
     for (i, xyzₛ) ∈ enumerate(xyz(x,y,z))
-        plot!(Val(:scatter), Val(Symbol(mode)), p, xyzₛ...; KWs[i]...)
+        kws = _make_magic(; KWs[i]...)
+        plot!(Val(:scatter), Val(Symbol(mode)), p, xyzₛ...; kws...)
     end
     p
 end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -17,6 +17,7 @@
 # scatter type
 # this step recycles arguments and x,y,z values
 SeriesType(::Val{:lines}) =  (:scatter, :lines)
+SeriesType(::Val{:sticks}) =  (:scatter, :sticks)
 SeriesType(::Val{:path3d}) = (:scatter, :lines)
 
 function plot!(::Val{:scatter}, p::Plot, x=nothing, y=nothing, z=nothing;
@@ -98,6 +99,21 @@ end
 ##
 function plot!(t::Val{:scatter}, p::Plot,
                f::Function, g::Function, a, b; kwargs...)
+end
+
+# sticks
+function plot!(t::Val{:scatter}, m::Val{:sticks}, p::Plot, x, y, z::Nothing; kwargs...)
+    n, T = length(x), eltype(x)
+    xs = Float64[]
+    ys = Float64[]
+    for (xᵢ, yᵢ) ∈ zip(x,y)
+        @show xᵢ
+        append!(xs, [xᵢ,xᵢ, NaN])
+        append!(ys, [0, yᵢ, yᵢ])
+    end
+    plot!(t, Val(:lines), p,xs, ys, nothing; kwargs...)
+    plot!(t, Val(:markers), p, x, y, nothing; kwargs...)
+    p
 end
 
 # Shape recipes

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -51,9 +51,15 @@ function plot!(::Val{:scatter}, m::Val{T}, p::Plot, x, y, z=nothing; kwargs...) 
     nothing
 end
 
+# plot vector by adding x
+function plot!(t::Val{:scatter}, m::Val{M}, p::Plot, x::AbstractVector{<:Real}, y::Nothing, z::Nothing; kwargs...) where {M}
+    plot!(t, m, p, 1:length(x),x; kwargs...)
+end
+
+
 # plot matrix by padding ut
 function plot!(t::Val{:scatter}, p::Plot,
-               x::AbstractMatrix, ::Nothing, ::Nothing; kwargs...)
+               x::AbstractMatrix{<:Real}, ::Nothing, ::Nothing; kwargs...)
     m, n = size(x)
     plot!(t, p, 1:m, x, nothing; kwargs...)
 end
@@ -96,9 +102,16 @@ function plot!(t::Val{:scatter}, m::Val{M}, p::Plot,
     throw(ArgumentError("parametric plots needs 2 or 3 functions"))
 end
 
-##
-function plot!(t::Val{:scatter}, p::Plot,
-               f::Function, g::Function, a, b; kwargs...)
+## # should just error
+function plot!(p::Plot,
+               f::Function, g::Function, as...)
+    @warn "use a tuple, `(f,g)`, to specify a parametric plot"
+    plot!(p, (f,g), as...; kwargs...)
+end
+function plot!(p::Plot,
+               f::Function, g::Function, h::Function , as...)
+    @warn "use a tuple, `(f,g,h)`, to specify a parametric plot"
+    plot!(p, (f,g,h), as...; kwargs...)
 end
 
 # sticks

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -25,8 +25,7 @@ function plot!(::Val{:scatter}, p::Plot, x=nothing, y=nothing, z=nothing;
     _,mode = SeriesType(seriestype)
     KWs = Recycler(kwargs)
     for (i, xyzₛ) ∈ enumerate(xyz(x,y,z))
-        kws = _make_magic(; KWs[i]...)
-        plot!(Val(:scatter), Val(Symbol(mode)), p, xyzₛ...; kws...)
+        plot!(Val(:scatter), Val(Symbol(mode)), p, xyzₛ...; KWs[i]...)
     end
     p
 end
@@ -43,7 +42,8 @@ function plot!(::Val{:scatter}, m::Val{T}, p::Plot, x, y, z=nothing; kwargs...) 
                z=_replace_infinite(z),
                type,
                mode=mode)
-    kws = _trace_styles!(c; kwargs...)
+    kws = _make_magic(; kwargs...)
+    kws = _trace_styles!(c; kws...)
     _merge!(c; kws...)
 
     push!(p.data, c)
@@ -98,7 +98,24 @@ end
 ##
 function plot!(t::Val{:scatter}, p::Plot,
                f::Function, g::Function, a, b; kwargs...)
-    @show :hi
+end
+
+# Shape recipes
+function plot!(t::Val{:scatter}, m::Val{:lines}, p::Plot, x::Shape, y::Nothing, z::Nothing; kwargs...)
+    plot!(t, m, p, x.x, x.y; kwargs...)
+end
+
+
+function plot!(t::Val{:scatter}, p::Plot, x::Vector{<:Shape}, y::Nothing, z::Nothing;
+               seriestype::Symbol=:lines,
+               kwargs...)
+
+    _,mode = SeriesType(seriestype)
+    KWs = Recycler(kwargs)
+    for (i, s) ∈ enumerate(x)
+        plot!(t, Val(Symbol(mode)),p, s; KWs[i]...)
+    end
+    p
 end
 
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -102,7 +102,12 @@ end
 
 # Shape recipes
 function plot!(t::Val{:scatter}, m::Val{:lines}, p::Plot, x::Shape, y::Nothing, z::Nothing; kwargs...)
-    plot!(t, m, p, x.x, x.y; kwargs...)
+    xs, ys = x.x, x.y
+    if (first(xs) != last(xs)) || (first(ys) != last(ys))
+        push!(xs, first(xs))
+        push!(ys, first(ys))
+    end
+    plot!(t, m, p, xs, ys; kwargs...)
 end
 
 

--- a/src/plots-lite.jl
+++ b/src/plots-lite.jl
@@ -1,5 +1,10 @@
 # This is the identifier of the type of visualization for this series. Choose from [:none, :line, :path, :steppre, :stepmid, :steppost, :sticks, :scatter, :heatmap, :hexbin, :barbins, :barhist, :histogram, :scatterbins, :scatterhist, :stepbins, :stephist, :bins2d, :histogram2d, :histogram3d, :density, :bar, :hline, :vline, :contour, :pie, :shape, :image, :path3d, :scatter3d, :surface, :wireframe, :contour3d, :volume, :mesh3d] or any series recipes which are defined.
 
+"""
+    SeriesType(x::Symbol)
+
+Return a type and mode for `plotly` based on a Plots.jl series type.
+"""
 SeriesType(x::Symbol) = SeriesType(Val(x))
 
 # this is all it takes to make
@@ -634,8 +639,12 @@ _align(x::Symbol, y::Symbol) = join((string(x), string(y)), " ")
 # for filled shapes
 function _fillstyle!(cfg::Config;
                      fc=nothing, fillcolor = fc, # string, symbol, RGB?
+                     fillrange=nothing, fill=fillrange,
                      kwargs...)
-    _merge!(cfg; fillcolor=fillcolor)
+    if !isnothing(fillcolor) && isnothing(fill)
+        fill = :toself
+    end
+    _merge!(cfg; fill, fillcolor)
     kwargs
 end
 
@@ -787,7 +796,7 @@ function _make_magic(;
     fill_styles = (:none,
                    :tozerox, :tonextx,
                    :tozeroy, :tonexty,
-                   :toself, :tonext)
+                   :toself,  :tonext)
     fillcolor = nothing
     fillalpha = nothing
     fillstyle = nothing

--- a/src/plots-lite.jl
+++ b/src/plots-lite.jl
@@ -549,6 +549,10 @@ function _textstyle!(cfg::Config;
     kwargs
 end
 
+
+function _shapestyle!(cfg; kwargs...)
+    _merge!(cfg, Config(kwargs...))
+end
 # https://docs.juliaplots.org/latest/attributes/#magic-arguments
 """
     font(args...)
@@ -902,6 +906,6 @@ end
 
 # recycle magic so that all is well in the world
 KWRecycler(::Val{T}, o) where {T} = Recycler(o) # default
-KWRecycler(::Val{:line}, o) = (@show o;MagicRecycler(o))
+KWRecycler(::Val{:line}, o) = MagicRecycler(o)
 KWRecycler(::Val{:marker}, o) =  MagicRecycler(o)
-KWRecycler(::Val{:fill}, o) = (@show o; MagicRecycler(o))
+KWRecycler(::Val{:fill}, o) = MagicRecycler(o)

--- a/src/plots-lite.jl
+++ b/src/plots-lite.jl
@@ -92,8 +92,8 @@ function plot!(t::Val{T}, p::Plot, x=nothing, y=nothing, z=nothing;
                seriestype::Symbol=:lines,
                kwargs...) where {T}
     _, mode = SeriesType(seriestype)
-    kws = _make_magic(; kwargs...) # XXX Is this needed here?
-    plot!(t, Val(mode), p, x, y, z; kwargs...)
+    kws = _make_magic(; kwargs...)
+    plot!(t, Val(mode), p, x, y, z; kws...)
 end
 
 # generic usage
@@ -827,6 +827,7 @@ function _layout_styles!(p;
                          xlabel=nothing, ylabel=nothing, zlabel=nothing,
                          xscale=nothing, yscale=nothing, zscale=nothing,
                          xaxis=nothing, yaxis=nothing, zaxis=nothing,
+                         background_color=nothing, background=background_color,bg=background_color, plot_bgcolor=bg,
                          legend=nothing,
 
                          kwargs...)
@@ -858,6 +859,9 @@ function _layout_styles!(p;
 
     # layout
     legend!(p, legend)
+
+    # attributes
+    p.layout.plot_bgcolor = plot_bgcolor
 
     # don't consume
     haskey(kwargs, :aspect_ratio) &&

--- a/src/plots-lite.jl
+++ b/src/plots-lite.jl
@@ -80,12 +80,17 @@ plot!(::Plot, args...; kwargs...) = throw(ArgumentError("No plot method defined"
 # XXX dispatch on type and mode
 # no xyz for surface type, say
 function plot!(p::Plot, x=nothing, y=nothing, z=nothing;
-               seriestype::Symbol=:lines,
+               seriestype= :lines,
                kwargs...)
     kws = _layout_styles!(p;  kwargs...) # adjust layout
-    type, mode =  SeriesType(seriestype)
-    plot!(Val(type), p, x, y, z; seriestype, kws...)
+    types = isa(seriestype, Symbol) ? (seriestype,) : tuple(seriestype...)
+    for seriestype in types
+        type, mode =  SeriesType(seriestype)
+        plot!(Val(type), p, x, y, z; seriestype, kws...)
+    end
+    p
 end
+
 
 # basic dispatch to type, then type/mode
 function plot!(t::Val{T}, p::Plot, x=nothing, y=nothing, z=nothing;

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -22,16 +22,9 @@ Shape(::Val{:hexagon}, args...)  = Shape(Val(:ngon),5)
 Shape(::Val{:heptogon}, args...) = Shape(Val(:ngon),7)
 Shape(::Val{:octogon}, args...)  = Shape(Val(:ngon),8)
 
-
-function Shape(::Val{:circle}, args...)
-    θs = range(0, 2pi, 100)
-    Shape(cos.(θs), sin.(θs))
-end
-
-
-
 Shape(::Val{:diamond}, r=1/2) = Shape([r,0,-r,0],[0,1,-1,0])
-
+shape(::Val{:hline}) = Shape([-1,1],[0,0])
+shape(::Val{:vline}) = Shape([0,0], [-1,1])
 function Shape(::Val{:star}, n=5, r = 1/4, args...)
     θs = range(0, 2pi, 2n+1)
     xs = zeros(Float64, 2n)
@@ -172,6 +165,8 @@ function _add_shapes!(p::Plot, ps; kwargs...)
     end
 end
 
+# _identity Broadcast to an iterable
+_identity(xs::Real...) = (xs,)
 _identity(xs...) = xs
 
 """

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -10,21 +10,26 @@ function Shape(s::Symbol, args...)
 end
 
 Shape(::Val{:unitsquare}, args...) = Shape([0,1,1,0],[0,0,1,1])
-function Shape(::Val{:ngon}, n, args...)
-    θs = range(0, 2pi, n+1)
+
+# unit circle shapes
+function Shape(::Val{:ngon}, n, offset=0, args...)
+    θs = range(offset*pi + 0, offset*pi + 2pi, n+1)
     Shape(sin.(θs), cos.(θs))
 end
+partialcircle(start_θ, end_θ, n = 20, r = 1) =
+    [(r * cos(u), r * sin(u)) for u in range(start_θ, stop = end_θ, length = n)]
 Shape(::Val{:circle}, args...)   = Shape(Val(:ngon), 100)
 Shape(::Val{:triangle}, args...) = Shape(Val(:ngon),3)
-Shape(::Val{:square}, args...) = Shape(Val(:ngon),4)
+Shape(::Val{:diamond}, args...) = Shape(Val(:ngon),4)
+Shape(::Val{:rect}, args...) = Shape(Val(:ngon),4,1/4)
 Shape(::Val{:pentagon}, args...) = Shape(Val(:ngon),5)
 Shape(::Val{:hexagon}, args...)  = Shape(Val(:ngon),5)
 Shape(::Val{:heptogon}, args...) = Shape(Val(:ngon),7)
 Shape(::Val{:octogon}, args...)  = Shape(Val(:ngon),8)
 
-Shape(::Val{:diamond}, r=1/2) = Shape([r,0,-r,0],[0,1,-1,0])
-shape(::Val{:hline}) = Shape([-1,1],[0,0])
-shape(::Val{:vline}) = Shape([0,0], [-1,1])
+Shape(::Val{:hline}) = Shape([-1,1],[0,0])
+Shape(::Val{:vline}) = Shape([0,0], [-1,1])
+
 function Shape(::Val{:star}, n=5, r = 1/4, args...)
     θs = range(0, 2pi, 2n+1)
     xs = zeros(Float64, 2n)
@@ -127,6 +132,11 @@ function center(s::Shape)
         Cy += (y[i] + y[ip1]) * m
     end
     Cx / 6A, Cy / 6A
+end
+
+function center!(s::Shape)
+    a,b = center(s)
+    translate!(s, -a, -b)
 end
 
 # shapes in Plotly use `layout` not `data`

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -1,3 +1,34 @@
+# Plots for making polygons
+## XXX need to do this
+## use Shape
+Base.copy(s::Shape) = Shape(copy(x), copy(y))
+scale(s::Shape, a) = Shape(a .* s.x, a .* s.y)
+function rotate(s::Shape, θ)
+    x, y = s.x, s.y
+    s, c = sincos(θ)
+    Shape(c*x - s*y, s*x + c*y)
+end
+translate(s::Shape, x, y) = Shape(x .+ s.x, y .+ s.y)
+function center(s::Shape)
+    _mean(x) = sum(x)/length(x)
+    translate(s, _mean(s.x), _mean(s.y))
+end
+function invert(s::Shape, axis=:x)
+    axis == :x && return Shape(s.x, -1 .* s.y)
+    axis == :y && return Shape(-1 .* s.x, s.y)
+    axis == :xy && return Shape(-1 .* s.x, -1 .* s.y)
+    s
+end
+shear(s::Shape, k) = Shape(s.x .+ (k .* s.y), s.y)
+
+Poly(x, y) = Shape(vcat(x, first(x)), vcat(y, first(y)))
+export Poly
+
+
+
+#Shape(x, y) = zip(x, y)
+#Shape(x) = x
+# XXX
 
 # generalize shapes (line, rect, circle, ...)
 # fillcolor

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -132,7 +132,8 @@ end
 
 
 function Recycler(kw::Base.Pairs)
-    y = Base.Pairs((;zip(keys(kw), [BinderPlots.Recycler(kw[k]) for k in keys(kw)])...), keys(kw))
+    rs = [KWRecycler(Val(k), kw[k]) for k in keys(kw)]
+    y = Base.Pairs((;zip(keys(kw), rs)...), keys(kw))
     Recycler(y, 0)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,4 @@
+# utils and types
 function _merge!(c::Config; kwargs...)
     for kv ∈ kwargs
         k,v = kv
@@ -283,12 +284,26 @@ function Base.range(start::_RGB, stop::_RGB, length::Integer)
 end
 
 ## Define Shape type
+## see shape.jl for methods
+"""
+    Shape(x, y)
+    Shape(vertices)
+
+Construct a *polygon* to be plotted
+"""
 struct Shape{X, Y}
     x::X
     y::Y
     function Shape(x::X,y::Y) where {X, Y}
         length(x) == length(y) || throw(ArgumentError("Need same length objects"))
-        new{X,Y}(x,y)
+        x′, y′ = float(x), float(y)
+        X′, Y′ = typeof(x′), typeof(y′)
+        new{X′,Y′}(x′, y′)
     end
-
 end
+
+function Shape(xy)
+    Shape(unzip(xy)...)
+end
+
+Base.copy(s::Shape) = Shape(copy(s.x), copy(s.y))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -234,6 +234,7 @@ end
 """
     rgb(r,g,b,α=1.0)
     rgb(c::Union{RGB, RGBA}) # RGB[A] from Colors.jl
+    rgb(::Symbol, α)
     colormap(cname, N; kwargs...)
 
 Specify red, green, blue values between 0 and 255 (as integers). The transparency is specified by the 4th argument, a value in [0.0,1.0].
@@ -257,6 +258,7 @@ function Base.convert(::Type{_RGB}, c::PlotUtils.Colors.RGBA)
 end
 rgb(c::PlotUtils.Colors.RGB) = convert(_RGB, c)
 rgb(c::PlotUtils.Colors.RGBA) = convert(_RGB, c)
+rgb(c::Symbol, α=1.0) = _RGB(PlotUtils.Colors.color_names[string(c)]..., α)
 
 PlotlyLight.StructTypes.StructType(::Type{_RGB}) = PlotlyLight.StructTypes.StringType()
 function Base.string(c::_RGB)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -281,3 +281,14 @@ function Base.range(start::_RGB, stop::_RGB, length::Integer)
     c2 = PlotUtils.Colors.RGBA(r,g,b,α)
     [rgb(c) for c ∈ range(c1, c2, length)]
 end
+
+## Define Shape type
+struct Shape{X, Y}
+    x::X
+    y::Y
+    function Shape(x::X,y::Y) where {X, Y}
+        length(x) == length(y) || throw(ArgumentError("Need same length objects"))
+        new{X,Y}(x,y)
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,11 +173,8 @@ end
 
     # vector//
     # Plots.jl will plot as a 1-column matrix so plot(1:n, v)
-    # not so here where it is assumed v is a vector of point
-    # so plot(v) -> plot(unzip(v)...)
-    # except for these methods
-    # vector// See below for special cases
-    @test_throws MethodError plot(xs)
+    # vector{<:Real}//
+    @test nseries(plot(xs)) == 1
 
     # /Vector{<:Function/[scalar]/[scalar] isa Vector{<:Function}
     plot(fs, a, b) # no plot(v) w/o plot(v,a,b) or plot(v, (a,b))
@@ -208,5 +205,19 @@ end
 
     plot(tuple(gs...), a, b)
     @test nseries() == 1
+
+    # cf. https://docs.juliaplots.org/latest/input_data/
+    # we don't bother with being so forgiving here
+    x1, x2 = [1, 0],  [2, 3]    # vectors
+    y1, y2 = [4, 5],  [6, 7]    # vectors
+    m1, m2 = [x1 y1], [x2 y2]   # 2x2 matrices
+
+
+    # array of matrices -> 4 series, plots each matrix column, x assumed to be integer count
+    @test_throws ArgumentError nseries(plot([m1, m2])) == 4
+    # array of array of arrays -> 4 series, plots each individual array, x assumed to be integer count
+    @test_throws MethodError nseries(plot([[x1,y1], [x2,y2]])) == 4
+    # array of tuples of arrays -> 2 series, plots each tuple as new series
+    @test_throws MethodError nseries(plot([(x1,y1), (x2,y2)]) ) == 2
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,7 +136,7 @@ end
 
     # use x/y/z to indicate calling pattern below
 
-    # matrix// each column a series agains 1:size(M,1)
+    # matrix// each column a series against 1:size(M,1)
     plot(M)
     @test nseries() == size(M,2)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using BinderPlots
-import BinderPlots: unzip
+import BinderPlots: unzip, translate
 using Test
 
 @testset "BinderPlots.jl" begin
@@ -46,7 +46,16 @@ end
 end
 
 @testset "shapes" begin
-    # shapes are definitely idiosyncratic
+    # Shape is of a polygon
+    square = Shape([(0, 0), (1, 0), (1, 1), (0, 1)])
+    usquare = Shape(:unitsquare) # test names
+    @test square.x == usquare.x  #
+    @test BinderPlots.rotate(square, 2pi).x ≈ square.x  # test rotation
+    @test BinderPlots.center(square) == (1/2, 1/2)      # test center
+    @test BinderPlots.center(BinderPlots.translate(square, 1, 2)) == (1 + 1/2, 2 + 1/2)  # test translate
+
+
+    # Other shapes are definitely idiosyncratic
     # 2d
     let
         p = plot()
@@ -108,5 +117,96 @@ end
         xs, ys, zs = unzip(r.(ts))
         skirt(xs, ys, zs, f)
     end
+
+end
+
+
+# test of every column is series
+@testset "number of series" begin
+    nseries(p::Plot=current()) = length(p.data)
+
+    # plot(x,y,z)
+    xs = 1:4
+    ys = [4,2,3,1]
+    zs = [1,3,5,7]
+    M = [1 2; 3 4; 5 6;7 8]
+    a, b = 0, 2pi
+    fs = [sin, cos]
+    gs = [sin, cos, exp]
+
+    # use x/y/z to indicate calling pattern below
+
+    # matrix// each column a series agains 1:size(M,1)
+    plot(M)
+    @test nseries() == size(M,2)
+
+    # vector/vector/
+    plot(xs, ys)
+    @test nseries() == 1
+
+    # vector/vector/vector
+    plot(xs, ys, zs)
+    @test nseries() == 1
+
+    # vector/matrix/ -- each column a series
+    plot(xs,M)
+    @test nseries() == size(M, 2)
+
+    # vector/matrix/matrix -- each column a series
+    plot(xs,M,M)
+    @test nseries() == size(M, 2)
+
+    # matrix/matrix/ -- each column paired off
+    plot(M, M)
+    @test nseries() == size(M, 2)
+
+    # matrix/matrix/matrx -- each column paired off
+    plot(M,M,M)
+    @test nseries() == size(M, 2)
+
+    #/Function/[scalar]/[scalar]
+    plot(first(fs), a, b)
+    @test nseries() == 1
+
+    plot(first(fs), (a, b))
+    @test nseries() == 1
+
+    # vector//
+    # Plots.jl will plot as a 1-column matrix so plot(1:n, v)
+    # not so here where it is assumed v is a vector of point
+    # so plot(v) -> plot(unzip(v)...)
+    # except for these methods
+    # vector// See below for special cases
+    @test_throws MethodError plot(xs)
+
+    # /Vector{<:Function/[scalar]/[scalar] isa Vector{<:Function}
+    plot(fs, a, b) # no plot(v) w/o plot(v,a,b) or plot(v, (a,b))
+    @test nseries() == length(fs)
+
+    n = nseries()
+    plot!(fs)
+    @test nseries() ==  n + length(fs)
+
+    plot(gs, a, b) # no plot(v) w/o plot(v,a,b) or plot(v, (a,b))
+    @test nseries() == length(gs)
+
+    n = nseries()
+    plot!(gs)
+    @test nseries() ==  n + length(gs)
+
+
+    # Vector{<:Shape}// plots each shape
+    s = Shape(:star, 5)
+    ss = [translate(s, k, k) for k in 0:5]
+    plot(ss)
+    @test nseries() == length(ss)
+
+    ##
+    # tuple(f,g)// parametric plot like above, `plot` needs a,b or (a,b)
+    plot(tuple(fs...), a, b)
+    @test nseries() == 1
+
+    plot(tuple(gs...), a, b)
+    @test nseries() == 1
 
 end


### PR DESCRIPTION
* Recycle magic arguments

* iterate over `seriestype` argument when passed as container

* Work on `Shape` type and methods to manipulate polygonal shapes
* default `fillrange` for `Shape`
* fix `abline` (not `ablines`)
* make `_shape` recycle arguments

* make `annotate` a bit more flexible when parsing `(x,y,text, as....)`

* add `sticks` series type
* add `plot(x::Vector)` method

* add `rgb(:symbol, alpha)` method

* test for number of series


